### PR TITLE
use astropy constants for c

### DIFF
--- a/SAGA/spectra/clean_repeats.py
+++ b/SAGA/spectra/clean_repeats.py
@@ -1,6 +1,6 @@
 import numpy as np
 from astropy.coordinates import SkyCoord
-from ..utils import SPEED_OF_LIGHT
+from astropy.constants import c
 
 def clean_repeats(spectra):
 
@@ -32,7 +32,7 @@ def clean_repeats(spectra):
         spec_sc = SkyCoord(spec['RA'], spec['DEC'], unit='deg')
 
         # search nearby spectra in 3D
-        nearby_mask = (np.abs(spectra['SPEC_Z'] - spec['SPEC_Z']) < 50.0/SPEED_OF_LIGHT)
+        nearby_mask = (np.abs(spectra['SPEC_Z'] - spec['SPEC_Z']) < 50.0/c.to('km/s').value)
         nearby_mask &= (spectra_sc.separation(spec_sc).arcsec < 30.0)
 
         specs_nearby = spectra[spectra_idx[nearby_mask]]

--- a/SAGA/utils/__init__.py
+++ b/SAGA/utils/__init__.py
@@ -6,7 +6,6 @@ This subpackage collects some handy functions.
 
 from .utils import (get_sdss_bands,
                     get_sdss_colors,
-                    SPEED_OF_LIGHT,
                     get_empty_str_array,
                     get_logger,
                     get_decals_viewer_image,

--- a/SAGA/utils/utils.py
+++ b/SAGA/utils/utils.py
@@ -9,8 +9,6 @@ from easyquery import Query
 from astropy.coordinates import search_around_sky, SkyCoord
 from astropy.units import Quantity
 
-SPEED_OF_LIGHT = 299792.458 # in km/s
-
 _sdss_bands = 'ugriz'
 
 


### PR DESCRIPTION
@yymao - This adjusts the one usage of `c` to get its value from `astropy.constants`.  The logic there is that that constant can be user-settable in a uniform way, and it shows at a glance what the *unit* is (you'll notice it uses the unit machinery to do this - constants are quantity objects, so there's no need to guess what the right unit is, and the overhead to do the conversion is basically microseconds).