### PR TITLE
Speed up object reading

### DIFF
--- a/SAGA/database/core.py
+++ b/SAGA/database/core.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 from astropy.table import Table
+from astropy.io import fits
 from ..utils import gzip_compress
 
 
@@ -47,12 +48,22 @@ class GoogleSheets(DataObject):
 
 
 class FitsTable(DataObject):
-    def __init__(self, path, compress_after_write=True):
+    def __init__(self, path, compress_after_write=True, masked_table=False):
         self._path = path
         self._compress_after_write = compress_after_write
+        self.masked_table = masked_table
 
     def _read(self):
-        return Table.read(self._path, format='fits')
+        # the read method *could* work in all cases, but it's slower than the
+        # other because it  accounts for masked values... but the SDSS catalog
+        # files seem to just be *wrong* in their treatement of masked/null
+        # values...so we use this other approach because it doesn't
+        # have the masking-associated overhead (which is useless here).
+        if self.masked_table:
+            return Table.read(self._path, format='fits')
+        else:
+            with fits.open(self._path) as f:
+                return Table(f[1].data)
 
     def _write(self, table, overwrite=False):
         if overwrite or not os.path.isfile(self._path):


### PR DESCRIPTION
This PR makes a couple of adjustments to speed things up when loading object catalogs.  Specifically:
* (optionally, but on by default) caches the loaded fits files so that they don't have to be re-read in the same python session
* uses a different way of loading fits tables into `Table` objects. @yymao, I figured out why this is quite a bit slower: the `Table.read` command accounts for masked values in a way that is consistent with the FITS standard but also has performance implications.  Normally that'd be *good*, but it looks like the SDSS catalogs are *not* properly implementing this masking.  So that feature is useless to us anyway, prompting this PR switching to an approach that ignores the masking.

Another performance item: it looks to me like most of the time in loading object catalogs is now taken up by un-gzipping the fits files.  So to get more significant speed enhancements we'd have to use a different/no compression.