### PR TITLE
add SAGA_name to host catalogs

### DIFF
--- a/SAGA/__init__.py
+++ b/SAGA/__init__.py
@@ -7,4 +7,4 @@ from .hosts import HostCatalog
 from .objects import ObjectCatalog, ObjectCuts
 from .targets import TargetSelection
 
-__version__ = '0.5.2'
+__version__ = '0.5.3'

--- a/SAGA/hosts/host_catalog.py
+++ b/SAGA/hosts/host_catalog.py
@@ -43,10 +43,6 @@ class HostCatalog(object):
 
     def __init__(self, database):
         self._database = database
-        try:
-            self._all_host_ids = self.load()['NSAID'].tolist()
-        except FileNotFoundError:
-            self._all_host_ids = []
 
         try:
             t = self._database['hosts_named'].read()
@@ -56,6 +52,11 @@ class HostCatalog(object):
         else:
             self._host_name_to_id = dict(zip((n.lower() for n in t['SAGA']), t['NSA']))
             self._host_id_to_name = dict(zip(t['NSA'], t['SAGA']))
+
+        try:
+            self._all_host_ids = self.load()['NSAID'].tolist()
+        except FileNotFoundError:
+            self._all_host_ids = []
 
 
     def resolve_id(self, hosts):
@@ -156,9 +157,18 @@ class HostCatalog(object):
         return self._annotate_catalog(res)
 
 
-    @staticmethod
-    def _annotate_catalog(table):
+    def _annotate_catalog(self, table):
+        names = []
+        for i in table['NSAID']:
+            try:
+                name = self.id_to_name(i)
+                names.append(name)
+            except KeyError:
+                names.append('')
+        table['SAGA_name'] = names
+
         table['coord'] = SkyCoord(table['RA'], table['Dec'], unit='deg')
+
         return table
 
 


### PR DESCRIPTION
This adds a bit to the host catalogs that adds the name used for hte SAGA object to the catalogs.  This turns out to make some tasks easier (as opposed) to having to do the `id_to_name` mapping manually any time you want the name
cc @yymao 