### PR TITLE
Fix remote downloads

### DIFF
--- a/SAGA/database/core.py
+++ b/SAGA/database/core.py
@@ -37,7 +37,13 @@ class FileObject(object):
         return Table.read(self.path, **self.kwargs)
 
     def write(self, table):
+        self._makedirs_if_needed(self.path)
         return table.write(self.path)
+
+    def _makedirs_if_needed(self, path):
+        dirs, fn = os.path.split(path)
+        if not os.path.exists(dirs):
+            os.makedirs(dirs)
 
     def download_as_file(self, file_path, overwrite=False, compress=False):
         if overwrite or not os.path.isfile(file_path):
@@ -67,6 +73,7 @@ class CsvTable(FileObject):
         return Table.read(self.path, format='ascii.csv', **self.kwargs)
 
     def write(self, table):
+        self._makedirs_if_needed(self.path)
         return table.write(self.path, format='ascii.csv')
 
 
@@ -92,6 +99,7 @@ class FitsTable(FileObject):
             table = table.copy()
             del table['coord']
         file_open = gzip.open if self.compress_after_write else open
+        self._makedirs_if_needed(self.path)
         with file_open(self.path, 'wb') as f_out:
             table.write(f_out, format='fits')
 
@@ -101,6 +109,7 @@ class NumpyBinary(FileObject):
         return np.load(self.path, **self.kwargs)
 
     def write(self, table):
+        self._makedirs_if_needed(self.path)
         np.savez(self.path, **table)
 
 

--- a/SAGA/database/core.py
+++ b/SAGA/database/core.py
@@ -40,7 +40,8 @@ class FileObject(object):
         self._makedirs_if_needed(self.path)
         return table.write(self.path)
 
-    def _makedirs_if_needed(self, path):
+    @staticmethod
+    def _makedirs_if_needed(path):
         dirs, fn = os.path.split(path)
         if not os.path.exists(dirs):
             os.makedirs(dirs)

--- a/SAGA/database/core.py
+++ b/SAGA/database/core.py
@@ -46,6 +46,7 @@ class FileObject(object):
             os.makedirs(dirs)
 
     def download_as_file(self, file_path, overwrite=False, compress=False):
+        self._makedirs_if_needed(file_path)
         if overwrite or not os.path.isfile(file_path):
             try:
                 r = requests.get(self.path, stream=True)
@@ -57,10 +58,10 @@ class FileObject(object):
                 try:
                     with file_open(file_path, 'wb') as f:
                         shutil.copyfileobj(r.raw, f)
-                except Exception as e:
-                    if os.path.isfile(f):
-                        os.unlink(f)
-                    raise e
+                except:
+                    if os.path.isfile(file_path):
+                        os.unlink(file_path)
+                    raise
 
     def isfile(self):
         if self.path:

--- a/SAGA/database/core.py
+++ b/SAGA/database/core.py
@@ -169,15 +169,15 @@ class DataObject(object):
             try:
                 table = self._get_local().read()
             except (IOError, OSError):
-                warnings.warn("Failed to read local file, try reading the remote file")
-                table = self.remote().read()
+                warnings.warn("Failed to read local file, will try reading the remote file")
+                table = self.remote.read()
         else:
             try:
                 table = self.remote.read()
             except Exception as read_exception: #pylint: disable=W0703
                 if self._get_local() is None:
                     raise read_exception
-                warnings.warn("Failed to read data, fall back to read local file")
+                warnings.warn("Failed to read data, falling back to try to read local file")
                 table = self._get_local().read()
 
         if self.cache_in_memory:

--- a/SAGA/objects/object_catalog.py
+++ b/SAGA/objects/object_catalog.py
@@ -215,7 +215,7 @@ class ObjectCatalog(object):
 
     def build_and_write_to_database(self, hosts=None, overwrite=False, base_file_path_pattern=None, version=2, return_catalogs=False, raise_exception=False):
         """
-        This function build base catalog and write to the database.
+        This function builds the base catalog and writes it to the database.
 
         !! IMPORTANT !!
         If you want to write the base catalog to an alternative location (not the database)


### PR DESCRIPTION
This fixes a few bugs I encountered in a few different contexts while trying to collect together all the downloaded files.  

It also adds functionality to auto-create the directories files should get downloaded to.  @yymao, I mostly point that out because if you want to create new `*Object` classes in `database/core.py` in the future, you'll want to remember to call the new private method at the start of the `write` method.