### PR TITLE
Warn when external catalogs are not found during base catalog building process

### DIFF
--- a/SAGA/objects/object_catalog.py
+++ b/SAGA/objects/object_catalog.py
@@ -275,6 +275,7 @@ class ObjectCatalog(object):
                 try:
                     cat = self._database[catalog_name, host_id].read()
                 except OSError:
+                    print(time.strftime('[%m/%d %H:%M:%S]'), '[WARNING] Not found: {} catalog for {}.'.format(catalog_name, host_id))
                     return None
                 return cat[build.WISE_COLS_USED] if catalog_name == 'wise' else cat
 


### PR DESCRIPTION
As title, a one-line simple PR to warn the users when external catalogs are not found during base catalog building process. 