### PR TITLE
Fix decalsprebuilt download

### DIFF
--- a/SAGA/database/core.py
+++ b/SAGA/database/core.py
@@ -7,6 +7,8 @@ import requests
 from astropy.table import Table
 from astropy.io import fits
 
+from ..utils import makedirs_if_needed
+
 try:
     FileExistsError
 except NameError:
@@ -37,17 +39,11 @@ class FileObject(object):
         return Table.read(self.path, **self.kwargs)
 
     def write(self, table):
-        self._makedirs_if_needed(self.path)
+        makedirs_if_needed(self.path)
         return table.write(self.path)
 
-    @staticmethod
-    def _makedirs_if_needed(path):
-        dirs, fn = os.path.split(path)
-        if not os.path.exists(dirs):
-            os.makedirs(dirs)
-
     def download_as_file(self, file_path, overwrite=False, compress=False):
-        self._makedirs_if_needed(file_path)
+        makedirs_if_needed(file_path)
         if overwrite or not os.path.isfile(file_path):
             try:
                 r = requests.get(self.path, stream=True)
@@ -75,7 +71,7 @@ class CsvTable(FileObject):
         return Table.read(self.path, format='ascii.csv', **self.kwargs)
 
     def write(self, table):
-        self._makedirs_if_needed(self.path)
+        makedirs_if_needed(self.path)
         return table.write(self.path, format='ascii.csv')
 
 
@@ -101,7 +97,7 @@ class FitsTable(FileObject):
             table = table.copy()
             del table['coord']
         file_open = gzip.open if self.compress_after_write else open
-        self._makedirs_if_needed(self.path)
+        makedirs_if_needed(self.path)
         with file_open(self.path, 'wb') as f_out:
             table.write(f_out, format='fits')
 
@@ -111,7 +107,7 @@ class NumpyBinary(FileObject):
         return np.load(self.path, **self.kwargs)
 
     def write(self, table):
-        self._makedirs_if_needed(self.path)
+        makedirs_if_needed(self.path)
         np.savez(self.path, **table)
 
 

--- a/SAGA/database/external.py
+++ b/SAGA/database/external.py
@@ -11,6 +11,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, vstack
 from .core import FitsTable
+from ..utils import makedirs_if_needed
 
 _HAS_CASJOBS_ = True
 try:
@@ -400,6 +401,7 @@ class DecalsPrebuilt(object):
         r = requests.get('http://www.slac.stanford.edu/~yymao/saga/base-catalogs-non-sdss/{}_decals_{}.fits.gz'.format(self.host_id, self.data_release),
                          headers={'Content-Type': 'application/gzip'},
                          stream=True)
+        makedirs_if_needed(file_path)
         with open(file_path, 'wb') as f:
             shutil.copyfileobj(r.raw, f)
 

--- a/SAGA/utils/functions.py
+++ b/SAGA/utils/functions.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import numpy as np
 from easyquery import Query
@@ -9,7 +10,8 @@ __all__ = ['get_sdss_bands', 'get_sdss_colors', 'get_des_bands', 'get_des_colors
            'get_decals_bands', 'get_decals_colors', 'get_all_bands', 'get_all_colors',
            'add_skycoord', 'get_empty_str_array', 'get_decals_viewer_image',
            'fill_values_by_query', 'get_remove_flag', 'view_table_as_2d_array',
-           'find_objid', 'find_near_objid', 'find_near_coord', 'find_near_ra_dec']
+           'find_objid', 'find_near_objid', 'find_near_coord', 'find_near_ra_dec',
+           'makedirs_if_needed']
 
 
 _sdss_bands = 'ugriz'
@@ -182,3 +184,12 @@ def view_table_as_2d_array(table, cols=None, row_mask=None, dtype=np.float64):
     row_mask = slice(None) if row_mask is None else row_mask
     cols = table.colnames if cols is None else cols
     return np.vstack((table[c][row_mask].data.astype(dtype, casting='same_kind', copy=False) for c in cols)).T
+
+def makedirs_if_needed(path):
+    """
+    Makes the directories in the path specified, if they don't exist. If they
+    already exist, this returns without doing anything.
+    """
+    dirs, fn = os.path.split(path)
+    if not os.path.exists(dirs):
+        os.makedirs(dirs)

--- a/SAGA/utils/functions.py
+++ b/SAGA/utils/functions.py
@@ -185,11 +185,12 @@ def view_table_as_2d_array(table, cols=None, row_mask=None, dtype=np.float64):
     cols = table.colnames if cols is None else cols
     return np.vstack((table[c][row_mask].data.astype(dtype, casting='same_kind', copy=False) for c in cols)).T
 
+
 def makedirs_if_needed(path):
     """
     Makes the directories in the path specified, if they don't exist. If they
     already exist, this returns without doing anything.
     """
-    dirs, fn = os.path.split(path)
+    dirs = os.path.dirname(path)
     if not os.path.exists(dirs):
         os.makedirs(dirs)


### PR DESCRIPTION
A follow-on to #32 - it turns out the `DecalsPrebuilt` class separately needs it. As a result, I realized it makes more sense to move `makedirs_if_needed` to the utilities module.