### PR TITLE
drop the removal of newlines from the query

### DIFF
--- a/SAGA/database/external.py
+++ b/SAGA/database/external.py
@@ -207,6 +207,7 @@ class SdssQuery(object):
 
         # ``**locals()`` means "use the local variable names to fill the template"
         q = cls._query_template.format(**locals())
+        q = re.sub(r'[^\S\n]+', ' ', q).strip()
         if not select_into_mydb:
             q = q.replace('INTO mydb.{} '.format(db_table_name), '')
         return q

--- a/SAGA/database/external.py
+++ b/SAGA/database/external.py
@@ -207,8 +207,6 @@ class SdssQuery(object):
 
         # ``**locals()`` means "use the local variable names to fill the template"
         q = cls._query_template.format(**locals())
-        q = re.sub(r'\s+', ' ', q).strip()
-        q = re.sub(', ', ',', q)
         if not select_into_mydb:
             q = q.replace('INTO mydb.{} '.format(db_table_name), '')
         return q


### PR DESCRIPTION
@yymao - this seems to be basically a minor change, but I find it's very useful for when I need to go in and look at my history on casjobs, or check the status of a slow casjobs query.  Am I missing something and it's important for functionality, though?