### PR TITLE
Target assignment fix

### DIFF
--- a/SAGA/targets/assign_targeting_score.py
+++ b/SAGA/targets/assign_targeting_score.py
@@ -220,14 +220,24 @@ def assign_targeting_score_v2(base, manual_selected_objids=None,
     if not testing:
         fill_values_by_query(base, C.has_spec, {'TARGETING_SCORE': 1400})
 
-    fill_values_by_query(base,
-                         Query(C.is_sat, (lambda x: (x != 'AAT') & (x != 'MMT'), 'TELNAME')),
-                         {'TARGETING_SCORE': 150})
+    fill_values_by_query(
+        base,
+        Query('ZQUALITY == 2', 'SPEC_Z < 0.05'),
+        {'TARGETING_SCORE': 180}
+    )
+
+    fill_values_by_query(
+        base,
+        Query(C.is_sat, (lambda x: (x != 'AAT') & (x != 'MMT'), 'TELNAME')),
+        {'TARGETING_SCORE': 150}
+    )
 
     if manual_selected_objids is not None:
-        fill_values_by_query(base, \
-                Query((lambda x: np.in1d(x, manual_selected_objids), 'OBJID')), \
-                {'TARGETING_SCORE': 100})
+        fill_values_by_query(
+            base,
+            Query((lambda x: np.in1d(x, manual_selected_objids), 'OBJID'), ~C.has_spec),
+            {'TARGETING_SCORE': 100}
+        )
 
     base.sort('TARGETING_SCORE')
     return base

--- a/SAGA/version.py
+++ b/SAGA/version.py
@@ -1,4 +1,4 @@
 """
 SAGA package version
 """
-__version__ = '0.6.21'
+__version__ = '0.6.22'


### PR DESCRIPTION
Fixes a few things in target assignment as suggested by @marlageha:
- manually selected objects exclude ones with ZQUALITY >= 3
- assign objects with ZQUALITY == 2 and SPEC_Z < 0.05 a targeting score of 180

version bumped to 0.6.22