### PR TITLE
Add a function to gather specs from all base catalogs

### DIFF
--- a/SAGA/version.py
+++ b/SAGA/version.py
@@ -1,4 +1,4 @@
 """
 SAGA package version
 """
-__version__ = '0.6.30'
+__version__ = '0.6.31'


### PR DESCRIPTION
This function is named `generate_clean_specs`, a member function of `SAGA.ObjectCatalog`. 

Version bumped to 0.6.31.