### PR TITLE
Improve photometric catalog merging process

### DIFF
--- a/SAGA/database/core.py
+++ b/SAGA/database/core.py
@@ -91,7 +91,7 @@ class FitsTable(FileObject):
     def read(self):
         with fits.open(self.path, cache=False, memmap=False, **self.kwargs) as hdu_list:
             # pylint: disable=E1101
-            t = Table(hdu_list[1].data)
+            t = Table(hdu_list[1].data, masked=False)
             del hdu_list[1].data
         return t
 

--- a/SAGA/database/core.py
+++ b/SAGA/database/core.py
@@ -90,7 +90,9 @@ class FitsTable(FileObject):
 
     def read(self):
         with fits.open(self.path, cache=False, memmap=False, **self.kwargs) as hdu_list:
-            t = Table.read(hdu_list, hdu=1)
+            # pylint: disable=E1101
+            t = Table(hdu_list[1].data)
+            del hdu_list[1].data
         return t
 
     def write(self, table):

--- a/SAGA/database/external.py
+++ b/SAGA/database/external.py
@@ -324,9 +324,8 @@ class DesQuery(object):
         d.MAGERR_AUTO_Y as y_err,
         d.flags_r,
         d.imaflags_iso_r,
-        (CASE WHEN (d.wavg_spread_model_i + 3*d.wavg_spreaderr_model_i) > 0.005 THEN 1 ELSE 0 END) +
-        (CASE WHEN (d.wavg_spread_model_i + d.wavg_spreaderr_model_i) > 0.003 THEN 1 ELSE 0 END) +
-        (CASE WHEN (d.wavg_spread_model_i - d.wavg_spreaderr_model_i) > 0.003 THEN 1 ELSE 0 END) as wavg_extended_coadd_i
+        (CASE WHEN d.wavg_spread_model_r == -99 THEN d.spread_model_r ELSE d.wavg_spread_model_r END) as spread_model_r,
+        (CASE WHEN d.wavg_spreaderr_model_r == -99 THEN d.spreaderr_model_r ELSE d.wavg_spreaderr_model_r END) as spreaderr_model_r
         from des_dr1.main d where
         q3c_radial_query(d.ra, d.dec, {ra:.7g}, {dec:.7g}, {r_deg:.7g})"""
 

--- a/SAGA/database/external.py
+++ b/SAGA/database/external.py
@@ -324,8 +324,8 @@ class DesQuery(object):
         d.MAGERR_AUTO_Y as y_err,
         d.flags_r,
         d.imaflags_iso_r,
-        (CASE WHEN d.wavg_spread_model_r == -99 THEN d.spread_model_r ELSE d.wavg_spread_model_r END) as spread_model_r,
-        (CASE WHEN d.wavg_spreaderr_model_r == -99 THEN d.spreaderr_model_r ELSE d.wavg_spreaderr_model_r END) as spreaderr_model_r
+        (CASE WHEN d.wavg_spread_model_r=-99 THEN d.spread_model_r ELSE d.wavg_spread_model_r END) as spread_model_r,
+        (CASE WHEN d.wavg_spreaderr_model_r=-99 THEN d.spreaderr_model_r ELSE d.wavg_spreaderr_model_r END) as spreaderr_model_r
         from des_dr1.main d where
         q3c_radial_query(d.ra, d.dec, {ra:.7g}, {dec:.7g}, {r_deg:.7g})"""
 
@@ -368,7 +368,7 @@ class DesQuery(object):
 
         r = requests.get('https://dlsvcs.datalab.noao.edu/query/query',
                          {'sql': self.query, 'ofmt': 'fits', 'async': False},
-                         headers={'Content-Type': 'application/octet-stream', 'X-DL-AuthToken': 'anonymous.0.0.anon_access'},
+                         headers={'Content-Type': 'application/octet-stream', 'X-DL-AuthToken': 'dltest.99998.99998.test_access'},
                          stream=True)
         if not r.ok:
             raise requests.RequestException('DES query failed: "{}"'.format(r.text))

--- a/SAGA/objects/build.py
+++ b/SAGA/objects/build.py
@@ -652,6 +652,7 @@ def find_satellites(base, version=1):
      3 - host galaxy itself
     91 - removed objects but otherwise satisfying satellite cut
     92 - removed objects but otherwise satisfying low-z galaxy cut
+    93 - too close to host but otherwise satisfying satellite
 
     `base` is modified in-place.
 
@@ -685,6 +686,10 @@ def find_satellites(base, version=1):
         fill_values_by_query(base, C.obj_is_host, {'SATS':3, 'REMOVE':-1})
     else:
         base['SATS'][base['RHOST_ARCM'].argmin()] = 3
+
+    # TODO: need a better way to fix this kind of issue:
+    if 'HOST_PGC' in base.colnames and base['HOST_PGC'][0] == 70094:
+        fill_values_by_query(base, Query('SATS == 1', 'RHOST_KPC < 24'), {'SATS':93})
 
     return base
 

--- a/SAGA/objects/build2.py
+++ b/SAGA/objects/build2.py
@@ -94,6 +94,7 @@ def prepare_sdss_catalog_for_merging(catalog, to_remove=None, to_recover=None):
         'abs(r_mag - i_mag) > 10',
         'abs(g_mag - r_mag) > 10',
         'FIBERMAG_R > 23',
+        'abs(u_mag - r_mag) > 10',
     ]
 
     catalog = set_remove_flag(catalog, remove_queries, to_remove, to_recover)
@@ -170,7 +171,7 @@ def prepare_decals_catalog_for_merging(catalog, to_remove=None, to_recover=None,
         catalog['r_mag'] += 0.1
         catalog['z_mag'] += 0.02
         catalog['radius'] = 1.14 * catalog['radius'] ** 0.446
-        catalog['radius_err'] *= (1.14 * 0.446 * catalog['radius'] ** (0.446-1))
+        catalog['radius_err'] *= np.where(catalog['radius'] > 0, (1.14 * 0.446 * catalog['radius'] ** (0.446-1)), 1)
 
     fill_values_by_query(catalog, Query('radius > 0', ~Query((np.isfinite, 'radius_err'))), {'radius_err': 9999.0})
 

--- a/SAGA/objects/build2.py
+++ b/SAGA/objects/build2.py
@@ -311,7 +311,7 @@ def merge_catalogs(debug=None, **catalog_dict):
             orig_idx = orig_idx[regroup_mask]
             del regroup_mask
 
-        del coord, orig_idx
+        del coord, orig_idx, stacked_catalog['survey_p']
 
     if debug is not None:
         debug['stacked_catalog'] = stacked_catalog.copy()
@@ -325,8 +325,7 @@ def merge_catalogs(debug=None, **catalog_dict):
                               uniq_col_name='{col_name}{table_name}',
                               table_names=['', '_'+name])
 
-    del merged_catalog['group_id']
-    del merged_catalog['chosen']
+    del stacked_catalog, merged_catalog['group_id'], merged_catalog['chosen']
 
     for name in catalog_dict:
         merged_catalog['OBJID_{}'.format(name)].fill_value = -1

--- a/SAGA/objects/build2.py
+++ b/SAGA/objects/build2.py
@@ -160,15 +160,19 @@ def prepare_decals_catalog_for_merging(catalog, to_remove=None, to_recover=None,
         {},
     )
     del mask
-    fill_values_by_query(catalog, Query('radius > 0', ~Query((np.isfinite, 'radius_err'))), {'radius_err': 9999.0})
 
     for band in 'uiy':
         catalog['{}_mag'.format(band)] = 99.0
         catalog['{}_err'.format(band)] = 99.0
 
     if convert_to_sdss_filters:
-        for band in 'grz':
-            catalog['{}_mag'.format(band)] += 0.1
+        catalog['g_mag'] += 0.09
+        catalog['r_mag'] += 0.1
+        catalog['z_mag'] += 0.02
+        catalog['radius'] = 1.14 * catalog['radius'] ** 0.446
+        catalog['radius_err'] *= (1.14 * 0.446 * catalog['radius'] ** (0.446-1))
+
+    fill_values_by_query(catalog, Query('radius > 0', ~Query((np.isfinite, 'radius_err'))), {'radius_err': 9999.0})
 
     remove_queries = [
         'FRACMASKED_G >= 0.35',

--- a/SAGA/objects/build2.py
+++ b/SAGA/objects/build2.py
@@ -161,6 +161,7 @@ def prepare_decals_catalog_for_merging(catalog, to_remove=None, to_recover=None,
         {},
     )
     del mask
+    fill_values_by_query(catalog, Query('radius > 0', ~Query((np.isfinite, 'radius_err'))), {'radius_err': 9999.0})
 
     for band in 'uiy':
         catalog['{}_mag'.format(band)] = 99.0
@@ -170,10 +171,6 @@ def prepare_decals_catalog_for_merging(catalog, to_remove=None, to_recover=None,
         catalog['g_mag'] += 0.09
         catalog['r_mag'] += 0.1
         catalog['z_mag'] += 0.02
-        catalog['radius'] = 1.14 * catalog['radius'] ** 0.446
-        catalog['radius_err'] *= np.where(catalog['radius'] > 0, (1.14 * 0.446 * catalog['radius'] ** (0.446-1)), 1)
-
-    fill_values_by_query(catalog, Query('radius > 0', ~Query((np.isfinite, 'radius_err'))), {'radius_err': 9999.0})
 
     remove_queries = [
         'FRACMASKED_G >= 0.35',

--- a/SAGA/objects/build2.py
+++ b/SAGA/objects/build2.py
@@ -106,8 +106,17 @@ def prepare_des_catalog_for_merging(catalog, to_remove=None, to_recover=None, co
     catalog['radius'] = catalog['radius_r']
     catalog['radius_err'] = np.float32(0)
 
-    catalog['is_galaxy'] = (catalog['wavg_extended_coadd_i'] >= 3)
-    catalog['morphology_info'] = catalog['wavg_extended_coadd_i'].astype(np.int32)
+    if 'wavg_extended_coadd_i' in catalog.colnames:
+        # only for backward compatibility
+        catalog['is_galaxy'] = (catalog['wavg_extended_coadd_i'] >= 3)
+        catalog['morphology_info'] = catalog['wavg_extended_coadd_i'].astype(np.int32)
+
+    else:
+        extended_coadd = (catalog['spread_model_r'] + catalog['spreaderr_model_r'] * 3.0 > 0.005).astype(np.int32)
+        extended_coadd += (catalog['spread_model_r'] + catalog['spreaderr_model_r'] > 0.003).astype(np.int32)
+        extended_coadd += (catalog['spread_model_r'] - catalog['spreaderr_model_r'] > 0.003).astype(np.int32)
+        catalog['is_galaxy'] = (extended_coadd == 3)
+        catalog['morphology_info'] = extended_coadd
 
     try:
         catalog.rename_column('ra', 'RA')

--- a/SAGA/objects/object_catalog.py
+++ b/SAGA/objects/object_catalog.py
@@ -80,7 +80,7 @@ class ObjectCatalog(object):
         return table
 
 
-    def load(self, hosts=None, has_spec=None, cuts=None, return_as=None, columns=None, version=None, to_add_skycoord=False):
+    def load(self, hosts=None, has_spec=None, cuts=None, return_as=None, columns=None, version=None, to_add_skycoord=True):
         """
         load object catalogs (aka "base catalogs")
 

--- a/SAGA/objects/object_catalog.py
+++ b/SAGA/objects/object_catalog.py
@@ -52,7 +52,7 @@ class ObjectCatalog(object):
 
 
     @staticmethod
-    def _annotate_catalog(table, to_add_skycoord=True):
+    def _annotate_catalog(table, to_add_skycoord=False):
         if 'EXTINCTION_R' in table.colnames:
             for b in get_sdss_bands():
                 table['{}_mag'.format(b)] = table[b] - table['EXTINCTION_{}'.format(b.upper())]
@@ -70,27 +70,17 @@ class ObjectCatalog(object):
 
 
     @staticmethod
-    def _slice_columns(table, columns, get_coord_later=False):
-        if columns is None:
-            return table
+    def _slice_columns(table, columns, to_add_skycoord=False):
+        if columns is not None:
+            table = table[columns]
 
-        if get_coord_later:
-            columns_this = list(columns)
-            try:
-                columns_this.remove('coord')
-            except ValueError:
-                pass
-            if 'RA' not in columns_this:
-                columns_this.append('RA')
-            if 'DEC' not in columns_this:
-                columns_this.append('DEC')
+        if to_add_skycoord:
+            table = add_skycoord(table)
 
-            return table[columns_this]
-
-        return table[columns]
+        return table
 
 
-    def load(self, hosts=None, has_spec=None, cuts=None, return_as=None, columns=None, version=None):
+    def load(self, hosts=None, has_spec=None, cuts=None, return_as=None, columns=None, version=None, to_add_skycoord=False):
         """
         load object catalogs (aka "base catalogs")
 
@@ -145,12 +135,6 @@ class ObjectCatalog(object):
         >>> bases_table = saga_object_catalog.load(hosts='paper1', cuts=C.basic_cut, return_as='stacked')
         """
 
-        if return_as is None:
-            return_as = 'stacked' if has_spec else 'list'
-        return_as = return_as.lower()
-        if return_as[0] not in 'slid':
-            raise ValueError('`return_as` should be "list", "stacked", "iter", or "dict"')
-
         if version is None:
             base_key = 'base'
         elif str(version).lower() in ('paper1', 'p1', 'v0p1', '0', '0.1'):
@@ -159,6 +143,12 @@ class ObjectCatalog(object):
             base_key = 'base_v{}'.format(version)
         else:
             raise ValueError('`version` must be None, \'paper1\', 1 or 2.')
+
+        if return_as is None:
+            return_as = 'stacked' if (has_spec and base_key == 'base_v0p1') else 'list'
+        return_as = return_as.lower()
+        if return_as[0] not in 'slid':
+            raise ValueError('`return_as` should be "list", "stacked", "iter", or "dict"')
 
         if has_spec and base_key == 'base_v0p1':
             t = self._database['saga_spectra_May2017'].read()
@@ -175,46 +165,48 @@ class ObjectCatalog(object):
             if return_as[0] != 's':
                 if hosts is None:
                     host_ids = np.unique(t['HOST_NSAID'])
-                output_iterator = (self._slice_columns(Query('HOST_NSAID == {}'.format(i)).filter(t), columns) for i in host_ids)
+                output_iterator = (self._slice_columns(Query('HOST_NSAID == {}'.format(i)).filter(t), columns, to_add_skycoord) for i in host_ids)
                 if return_as[0] == 'i':
                     return output_iterator
                 if return_as[0] == 'd':
                     return dict(zip(host_ids, output_iterator))
                 return list(output_iterator)
 
-            return self._slice_columns(t, columns)
+            return self._slice_columns(t, columns, to_add_skycoord)
 
-        else:
-            q = Query(cuts)
-            if has_spec:
-                q = q & C.has_spec
-            elif has_spec is not None:
-                q = q & (~C.has_spec)
+        q = Query(cuts)
+        if has_spec:
+            q = q & C.has_spec
+        elif has_spec is not None:
+            q = q & (~C.has_spec)
 
-            hosts = self._host_catalog.resolve_id(hosts, 'string')
+        hosts = self._host_catalog.resolve_id(hosts, 'string')
 
-            need_coord = (columns is None or 'coord' in columns)
-            to_add_skycoord = (need_coord and return_as[0] != 's') # because skycoord cannot be stacked
+        output_iterator = (
+            self._slice_columns(
+                q.filter(self._annotate_catalog(self._database[base_key, host].read())),
+                columns,
+                (to_add_skycoord and return_as[0] != 's')
+            ) for host in hosts
+        )
 
-            output_iterator = (self._slice_columns(q.filter(self._annotate_catalog(self._database[base_key, host].read(), to_add_skycoord)), columns, (need_coord and not to_add_skycoord)) for host in hosts)
-
-            if return_as[0] == 'i':
-                return output_iterator
-            if return_as[0] == 's':
-                out = vstack(list(output_iterator), 'outer', 'error')
-                if out.masked:
-                    for name, (dtype, _) in out.dtype.fields.items():
-                        if dtype.kind == 'i':
-                            out[name].fill_value = -1
-                        if dtype.kind == 'b':
-                            out[name].fill_value = False
-                out = out.filled()
-                if need_coord:
-                    out = self._slice_columns(add_skycoord(out), columns)
-                return out
-            if return_as[0] == 'd':
-                return dict(zip(hosts, output_iterator))
-            return list(output_iterator)
+        if return_as[0] == 'i':
+            return output_iterator
+        if return_as[0] == 's':
+            out = vstack(list(output_iterator), 'outer', 'error')
+            if out.masked:
+                for name, (dtype, _) in out.dtype.fields.items():
+                    if dtype.kind == 'i':
+                        out[name].fill_value = -1
+                    if dtype.kind == 'b':
+                        out[name].fill_value = False
+            out = out.filled()
+            if to_add_skycoord:
+                out = add_skycoord(out)
+            return out
+        if return_as[0] == 'd':
+            return dict(zip(hosts, output_iterator))
+        return list(output_iterator)
 
 
     def load_nsa(self, version='0.1.2'):

--- a/SAGA/targets/target_selection.py
+++ b/SAGA/targets/target_selection.py
@@ -222,12 +222,20 @@ def prepare_mmt_catalog(target_catalog, write_to=None, verbose=True,
         is_flux_star &= Query('PSFMAG_G - PSFMAG_R >= 0', 'PSFMAG_G - PSFMAG_R < 0.6')
         is_flux_star &= Query('(PSFMAG_G - PSFMAG_R) > 0.75 * (PSFMAG_U - PSFMAG_G) - 0.45')
     else:
-        is_star = Query((lambda x: x == 'sdss', 'survey'), 'morphology_info == 6')
-        is_guide_star = is_star & Query('r_mag >= 14', 'r_mag < 15')
-        is_flux_star = is_star & Query('r_mag >= 17', 'r_mag < 18')
-        is_flux_star &= Query('ug >= 0.6', 'ug < 1.2')
-        is_flux_star &= Query('gr >= 0', 'gr < 0.6')
-        is_flux_star &= Query('gr > 0.75 * ug - 0.45')
+        is_star = ~Query('is_galaxy')
+        if 'OBJID_sdss' in target_catalog.colnames:
+            is_star &= Query('OBJID_sdss != -1', 'morphology_info_sdss == 6')
+            is_guide_star = is_star & Query('r_mag_sdss >= 14', 'r_mag_sdss < 15')
+            is_flux_star = is_star & Query('r_mag_sdss >= 17', 'r_mag_sdss < 18')
+            is_flux_star &= Query('u_mag_sdss - g_mag_sdss >= 0.6', 'u_mag_sdss - g_mag_sdss < 1.2')
+            is_flux_star &= Query('g_mag_sdss - r_mag_sdss >= 0', 'g_mag_sdss - r_mag_sdss < 0.6')
+            is_flux_star &= Query('g_mag_sdss - r_mag_sdss > 0.75 * (u_mag_sdss - g_mag_sdss) - 0.45')
+        else:
+            is_guide_star = is_star & Query('r_mag >= 14', 'r_mag < 15')
+            is_flux_star = is_star & Query('r_mag >= 17', 'r_mag < 18')
+            is_flux_star &= Query('ug >= 0.6', 'ug < 1.2')
+            is_flux_star &= Query('gr >= 0', 'gr < 0.6')
+            is_flux_star &= Query('gr > 0.75 * ug - 0.45')
 
     target_catalog = (is_target | is_guide_star | is_flux_star).filter(target_catalog)
 

--- a/SAGA/version.py
+++ b/SAGA/version.py
@@ -1,4 +1,4 @@
 """
 SAGA package version
 """
-__version__ = '0.9.13'
+__version__ = '0.10.0'


### PR DESCRIPTION
This PR improves the merging process of  photometric catalogs (SDSS, DES, DECaLS). The main changes are:
- Do not always favor the brightest object in a FoF group. Instead, favor deeper images (DES > DECaLS > SDSS) as long as they don't have remove flag set. 
- In the FoF merging step, distinguish the case of a 2-2 merge (which requires a re-group with smaller linking length) and 1-3 merge (which may not requires re-group), and other similar cases.
