### PR TITLE
move most deps out of optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,12 @@ setup(
         "astropy>=2.0",
         "easyquery>=0.1.5",
         "requests>=2.18",
+        "healpy>=1.12",
+        "fast3tree>=0.3.1",
+        "scikit-learn",
+        "pyperclip"
     ],
     extras_require={
-        "full": ["healpy>=1.12", "fast3tree>=0.3.1", "ipython", "scikit-learn", "pyperclip"],
+        "full": ["ipython"],
     },
 )


### PR DESCRIPTION
Just a thought, @yymao - I was installing re-installing SAGA today to test something, and for the third time ran into the "I need to install healpy" error.  So I'm thinking, given this is already a rather science-case-specific package, if it's better to just have most of the deps be "real" deps instead of extras? (ipython I agree still makes sense as optional since it's really only for a few specific workflows)