### PR TITLE
datalab.noao.edu-> datalab.noirlab.edu

### DIFF
--- a/SAGA/database/external.py
+++ b/SAGA/database/external.py
@@ -483,7 +483,7 @@ class DatalabQuery(DownloadableBase):
 
         # taken from https://github.com/noaodatalab/datalab/blob/master/dl/queryClient.py#L1791
         r = requests.get(
-            "https://datalab.noao.edu/query/query",
+            "https://datalab.noirlab.edu/query/query",
             {"sql": query, "ofmt": "ascii", "async": False},
             headers={
                 "Content-Type": "application/octet-stream",


### PR DESCRIPTION
Looks like they turned off the noao.edu URL permanently...